### PR TITLE
fix: memperbaiki pop element testing

### DIFF
--- a/implementation/implementation.cpp
+++ b/implementation/implementation.cpp
@@ -3,8 +3,7 @@
 #include "../header/forward_list.hpp"
 int main(){
     std::cout << "Pop Front" << std::endl;
-    forward_lists<int>flst = {1,2,3};
-    flst.pop_front();
+    forward_lists<int>flst = {1,2,3,4,5};
     flst.pop_front();
     flst.print_all(flst.begin(),flst.end()); //3
     //initializer list

--- a/refactor.md
+++ b/refactor.md
@@ -1,0 +1,7 @@
+## Pengingat refactor
+refactor method erase_after pertama
+```cpp
+Node* dlt = iter_position->next;
+iter_position->next = dlt->next;
+delete dlt;
+```

--- a/task.save
+++ b/task.save
@@ -1,0 +1,13 @@
+create database db_genap1
+create table karyawan
+id  int
+nama  varchar
+bagian varchar 
+gaji double
+
+masukkan banyak data
+nama table: bagian
+buat kolom
+Kode_bagian int  
+Nama_bagian varchar 50
+Nama_manajer varchar 50 

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,35 @@
+#include <bits/stdc++.h>
+void sliding_window(){
+    std::vector<int>nums = {1,4,6,3,9};
+    int target = 18;
+    int n = 3;
+    int sum = 0;
+    for(int i = 0;i < n;i++){
+        sum += nums[i];
+    }
+    int window = sum;
+    if(window == target){
+        std::cout << "Target ditemukan" << std::endl;
+    }else{
+        bool checked = false;
+        for(size_t i = n;i < nums.size();i++){
+            window += nums[i] + nums[i - n];
+            if(window == target){
+                checked = true;
+                break;
+            }
+        }
+        if(checked == false){
+            std::cout << "Target tidak ditemukan" << std::endl;
+        }else{
+            std::cout << "Target ditemukan" << std::endl;
+
+        }
+    }
+}
+int main(){
+    std::forward_list<int>sl;
+    std::cout << sl.max_size() << std::endl;
+    std::cin.get();
+    return 0;
+}

--- a/test/testing.cpp
+++ b/test/testing.cpp
@@ -13,6 +13,19 @@ TEST(Basic_stl,check_front){
     EXPECT_EQ(fl.front(), 1);
     EXPECT_FALSE(fl.is_empty());
 }
+TEST(Basic_stl,pop_element){
+    forward_lists<int>fl = {1,2,3,4,5};
+    fl.pop_front();
+    std::vector<int>actual;
+    std::vector<int>expectation = {2,3,4,5};
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_TRUE(!fl.is_empty());
+    EXPECT_EQ(fl.get_size(),3);
+    EXPECT_EQ(actual, expectation);
+}
+
 TEST(Constructor_testing,initializer_constructor_test){
     forward_lists<int>fl = {1,2,3};
     std::vector<int>ex = {1,2,3};
@@ -41,7 +54,30 @@ TEST(Insert_testing,push_testing){
     fl.push_front(1);
     fl.push_front(2);
     fl.push_front(3);
-    int x = 4;
+    std::vector<int>ex = {3,2,1};
+    std::vector<int>actual;
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_EQ(actual,ex);
+    EXPECT_FALSE(fl.is_empty());
+    EXPECT_EQ(fl.get_size(), 3);
+}
+TEST(Insert_testing, push_lvalue_testing){
+    forward_lists<int>fl;
+    int x,y,z;
+    x = 10;
+    y = 20;
+    z = 30;
     fl.push_front(x);
-    std::vector<int>ex = {4,3,2,1};
+    fl.push_front(y);
+    fl.push_front(z);
+    std::vector<int>actual;
+    std::vector<int>ex = {30,20,10};
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_EQ(actual, ex);
+    EXPECT_FALSE(fl.is_empty());
+    EXPECT_EQ(fl.get_size(), 3);
 }

--- a/test/testing.cpp
+++ b/test/testing.cpp
@@ -7,7 +7,6 @@ TEST(Basic_stl,check_empty){
     EXPECT_EQ(fl.get_size(), 0);
     EXPECT_TRUE(fl.is_empty());
 }
-
 TEST(Basic_stl,check_front){
     forward_lists<int>fl = {1};
     EXPECT_EQ(fl.front(), 1);
@@ -15,17 +14,18 @@ TEST(Basic_stl,check_front){
 }
 TEST(Basic_stl,pop_element){
     forward_lists<int>fl = {1,2,3,4,5};
+    EXPECT_EQ(fl.get_size(),5);
+    EXPECT_EQ(fl.front(), 1);
     fl.pop_front();
     std::vector<int>actual;
     std::vector<int>expectation = {2,3,4,5};
     for(auto x: fl){
         actual.push_back(x);
     }
-    EXPECT_TRUE(!fl.is_empty());
-    EXPECT_EQ(fl.get_size(),3);
+    EXPECT_FALSE(fl.is_empty());
+    EXPECT_EQ(fl.get_size(),4);
     EXPECT_EQ(actual, expectation);
 }
-
 TEST(Constructor_testing,initializer_constructor_test){
     forward_lists<int>fl = {1,2,3};
     std::vector<int>ex = {1,2,3};
@@ -67,7 +67,7 @@ TEST(Insert_testing, push_lvalue_testing){
     forward_lists<int>fl;
     int x,y,z;
     x = 10;
-    y = 20;
+    y = 20; 
     z = 30;
     fl.push_front(x);
     fl.push_front(y);


### PR DESCRIPTION
## feat: Judul Perubahan
<!-- Contoh: feat: Menambahkan Linked List -->
## Perubahan yang diberikan
1. **`get_size`**
sebelumnya pada testing saya memakai indexed dalam menghitung size,yang dimana saya menghitung mulai dari 0 seperti array,ini jelas salah karena pada list tidak memakai indexed.Berikut perbaikannya
```cpp

TEST(Basic_stl,pop_element){
    forward_lists<int>fl = {1,2,3,4,5};
    EXPECT_EQ(fl.get_size(),5);
    EXPECT_EQ(fl.front(), 1);
    fl.pop_front();
    std::vector<int>actual;
    std::vector<int>expectation = {2,3,4,5};
    for(auto x: fl){
        actual.push_back(x);
    }
    EXPECT_FALSE(fl.is_empty());
    EXPECT_EQ(fl.get_size(),4);
    EXPECT_EQ(actual, expectation);
}
```
hasil test
```bash
100% tests passed, 0 tests failed out of 7
```
---

# Checklist
##### Umum:
- [x] Saya menambah algoritma terbaru.
- [x] Saya menambah dokumentasi.

##### Contributor Requirements (Syarat Kontributor) dan Lain-Lain:
- [x] Saya telah menambahkan komentar kode yang memberikan penjelasan maksud dari kode yang saya buat.
- [x] Saya menggunakan bahasa Indonesia untuk memberikan penjelasan dari kode yang saya buat.

---

# Environment
Saya menggunakan (I'm using):
- ``OS`` = `Linux` <!-- if you dont use linux you can rewrite this --> 
- ``g++`` = `15.2.1`

---

# Link Issues

Issues: # <!-- if don't have a issue,please do not fill this>

---

# License
This Commit License  
https://github.com/Build-X-From-Scratch/forward_list_sratch/blob/main/LICENSE