### PR TITLE
update: menambahkan custom iterator input

### DIFF
--- a/header/forward_list.hpp
+++ b/header/forward_list.hpp
@@ -4,8 +4,15 @@
 #include <iterator>
 #include <cstddef>
 #include <limits>
+#include <concepts>
 #ifndef __forwardList
 #define __forwardList
+template <typename It>
+concept my_input_iterator = requires(It it){
+    *it; //bisa di deferencing
+    ++it; //bisa post increment
+    it++; //bisa pre increment
+};
 template <typename T>
 class forward_lists{
     private:
@@ -32,12 +39,12 @@ class forward_lists{
          * @details time complexity o(n), dan space complexity O(n)
          * 
          */
-        template<typename inputIterator>
-        requires std::input_iterator<inputIterator>
-        forward_lists(inputIterator begin,inputIterator end): head(nullptr),size(0){
+        template <typename It>  
+        requires my_input_iterator<It>
+        forward_lists(It begin,It end): head(nullptr),size(0){
             head = new Node(T{});
-            head->next = nullptr;
             size = 0;
+            head->next = nullptr;
             Node** curr = &head->next; //curr menunjuk head->next
             while(begin != end){
                 *curr = new Node(*begin); //isi node
@@ -50,7 +57,7 @@ class forward_lists{
          * @brief initializer list constructor
          * @details
          */
-        forward_lists(std::initializer_list<T> arr): head(nullptr),size(0){
+        forward_lists(std::initializer_list<T> arr): head(nullptr){
             head = new Node(T{});
             head->next = nullptr;
             size = 0;
@@ -110,7 +117,7 @@ class forward_lists{
          */
         forward_lists(forward_lists&& others) noexcept : head(nullptr){
             head = others.head;
-            others.head == nullptr; //kosongkan others lama agar tidak memory leak
+            others.head = nullptr; //kosongkan others lama agar tidak memory leak
         }
         /**
          * @brief move assignment constructor

--- a/test/testing.cpp
+++ b/test/testing.cpp
@@ -37,6 +37,23 @@ TEST(Constructor_testing,initializer_constructor_test){
     EXPECT_FALSE(fl.is_empty());
     EXPECT_EQ(fl.get_size(), 3);
 }
+TEST(Constructor_testing, range_constructor){
+    std::vector<int>cp = {1,2,3};
+    forward_lists<int>fl(cp.begin(),cp.end());
+    std::vector<int>expec;
+    std::vector<int>actual = {1,2,3};
+    for(auto x: fl){
+        expec.push_back(x);
+    }
+    EXPECT_EQ(actual, expec);
+    forward_lists<int>range = {1,2,3,};
+    forward_lists<int>mv(range.begin(),range.end());
+    std::vector<int>expectations;
+    for(auto x: mv){
+        expectations.push_back(x);
+    }
+    EXPECT_EQ(actual,expectations);
+}
 TEST(Constructor_testing,basic_constructor_test){
     forward_lists<int>fl;
     fl.push_front(1);


### PR DESCRIPTION
## update: menambahkan custom iterator input
<!-- Contoh: feat: Menambahkan Linked List -->
## Perubahan yang diberikan
Sebelum nya range constructor hanya dapat menerima input iterator dari iterator container lain,untuk itu dibutuhkan custom iterator supaya bisa menerima input iterator dari iterator forward_list,
```cpp
template <typename It>
concept my_input_iterator = requires(It it){
    *it; //bisa di deferencing
    ++it; //bisa post increment
    it++; //bisa pre increment
};
```
dengan ini range constructor dapat menerima input iterator dari berbagai container dengan beberapa syarat
- bisa di deferencing
- bisa post increment
- bisa pre increment
2. **Memperbaiki bug kecil pada move constructor**
sebelum saya menggunakan operator comparison `head == nullptr`.
```cpp
forward_lists(forward_lists&& others) noexcept : head(nullptr){
            head = others.head;
            others.head = nullptr; //kosongkan others lama agar tidak memory leak
        }
```

---

# Checklist
##### Umum:
- [x] Saya menambah algoritma terbaru.
- [x] Saya menambah dokumentasi.

##### Contributor Requirements (Syarat Kontributor) dan Lain-Lain:
- [x] Saya telah menambahkan komentar kode yang memberikan penjelasan maksud dari kode yang saya buat.
- [x] Saya menggunakan bahasa Indonesia untuk memberikan penjelasan dari kode yang saya buat.

---

# Environment
Saya menggunakan (I'm using):
- ``OS`` = `Linux` <!-- if you dont use linux you can rewrite this --> 
- ``g++`` = `15.2.1`

---

# Link Issues

Issues: # <!-- if don't have a issue,please do not fill this>

---

# License
This Commit License  
https://github.com/Build-X-From-Scratch/forward_list_sratch/blob/main/LICENSE