### PR TITLE
fix: size tidak increment pada insert method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# List_From_Scratch
+# Forward List Standar Template Library
+![C++](https://img.shields.io/badge/C++-20-blue.svg)
+![Build](https://img.shields.io/badge/build-passing-brightgreen)
+![License](https://img.shields.io/badge/license-MIT-orange)

--- a/header/forward_list.hpp
+++ b/header/forward_list.hpp
@@ -361,15 +361,12 @@ class forward_lists{
                 curr->next = new_node;
             }
         }
-        template<typename pos>
-        void insert_after(Iterator iter_position,pos itr1,pos itr2){
-            using category = typename std::iterator_traits<pos>::iterator_category;
-            static_assert(
-                std::is_base_of_v<std::input_iterator_tag,category>,
-                "parameter harus iterator"
-            );
+        template<std::input_iterator It>
+        requires (!std::same_as<It,Iterator>)
+        void insert_after(Iterator iter_position,It itr1,It itr2){
             Node* curr = iter_position.get_raw();
             Node* new_node = new Node(*itr1);
+            size++;
             Node* tail = new_node;
             ++itr1;
             while(itr1 != itr2){
@@ -377,6 +374,7 @@ class forward_lists{
                 ++itr1;
                 tail->next = n_node;
                 tail = n_node;
+                size++;
             }
             tail->next = curr->next;
             curr->next = new_node;
@@ -384,14 +382,17 @@ class forward_lists{
         void insert_after(const Iterator iter_position,Iterator listBegin,const Iterator listEnd){
             Node* curr = iter_position.get_raw();
             Node* new_head = listBegin.get_raw();
+            Node* end = listEnd.get_raw();
             Node* new_node = new Node(new_head->data);
+            size++;
             Node* tail = new_node;
             new_head = new_head->next;   
-            while(listBegin != listEnd){
+            while(new_head != end){
                 Node* n_node = new Node(new_head->data);
                 tail->next = n_node;
                 tail = n_node;
                 new_head = new_head->next; 
+                size++;
             }
             tail->next = curr->next;
             curr->next = new_node;
@@ -404,6 +405,7 @@ class forward_lists{
             }
             Node* temp = curr->next;
             curr->next = temp->next;
+            size--;
             delete temp;
         }
         void erase_after(const Iterator pos_begin,const Iterator pos_end){
@@ -415,6 +417,7 @@ class forward_lists{
                 Node* temp = curr;
                 curr = curr->next;
                 delete temp;
+                size--;
             }
             first->next = last;
         }

--- a/implementation/implementation.cpp
+++ b/implementation/implementation.cpp
@@ -67,5 +67,13 @@ int main(){
     abs.erase_after(abs.begin(),abs.end());
     abs.print_all(abs.begin(),abs.end());
     //std::cin.get();
+    //================segfaul===========================
+    std::cout << "Disini segfault" << std::endl;
+    forward_lists<int>list = {10,20,30,40,50,60,70,80,90,100};
+   list.print_all(list.begin(),list.end());  
+    std::cout << list.get_size() << std::endl;
+    list.erase_after(list.begin());
+    list.print_all(list.begin(),list.end());    
+    std::cout << list.get_size() << std::endl;
     return 0;
 }   

--- a/test/testing.cpp
+++ b/test/testing.cpp
@@ -98,3 +98,47 @@ TEST(Insert_testing, push_lvalue_testing){
     EXPECT_FALSE(fl.is_empty());
     EXPECT_EQ(fl.get_size(), 3);
 }
+TEST(Insert_testing,insert_afterII){
+    forward_lists<int>fl = {1,2,3};
+    std::vector<int>v = {10,20,30};
+    fl.insert_after(fl.begin(),v.begin(),v.end());
+    std::vector<int>expectations = {1,10,20,30,2,3};
+    std::vector<int>actual;
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_EQ(actual,expectations);
+    EXPECT_EQ(fl.get_size(),6);
+    EXPECT_FALSE(fl.is_empty());
+}
+TEST(Insert_testing,insert_afterIII){
+    forward_lists<int>fl = {1,2,3,4,5};
+    EXPECT_EQ(fl.get_size(),5);
+    forward_lists<int>flst;
+    EXPECT_TRUE(flst.is_empty());
+    flst.push_front(10);
+    flst.push_front(20);
+    flst.push_front(30);
+    EXPECT_EQ(flst.get_size(),3);
+    //flst  = {30 20 10}
+    fl.insert_after(fl.begin(),flst.begin(),flst.end());
+    std::vector<int>expectations = {1,30,20,10,2,3,4,5};
+    std::vector<int>actual;
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_EQ(actual,expectations);
+    EXPECT_EQ(fl.get_size(),8);
+}
+TEST(erase_testing,erase_afterI){
+    forward_lists<int>fl = {10,20,30,40,50,60,70,80,90,100};
+    EXPECT_EQ(fl.get_size(),10);
+    fl.erase_after(fl.begin());
+    std::vector<int>expectations = {10,30,40,50,60,70,80,90,100};
+    std::vector<int>actual;
+    for(auto x: fl){
+        actual.push_back(x);
+    }
+    EXPECT_EQ(fl.get_size(),9);
+    EXPECT_EQ(actual,expectations);
+}


### PR DESCRIPTION
## fix: size tidak increment pada insert method
<!-- Contoh: feat: Menambahkan Linked List -->

# Deskripsi (Description)
## Perubahan yang diberikan
1. **Fix Tidak increment pada saat `insert_after`*
Pada method `insert_after` dan overload functionnya ada beberapa bug yaitu `size` lupa di increment pada saat insertion mengakibatkan `size` tidak bertambah dan membuat testing gagal.

2. **Menambahkan unit testing untuk overload `insert after`**
Masing-masing overload untuk `insert_after` sudah dibuatkan unit testing dengan 100% passed test. 
3.**Memperbaiki Input Iterator pada `Insert_after`**
pada overload insert_after berikut:
```cpp
void insert_after(Iterator iter_position,It itr1,It itr2)
```
terkadang dapat bertabrakan dengan overload function berikut:
```cpp
 void insert_after(const Iterator iter_position,Iterator listBegin,const Iterator listEnd)
```
saya menambahkan template baru agar Input Iterator pada method pertama tidak bertabrakan dengan method kedua yaitu:
```cpp
template<std::input_iterator It>
requires (!std::same_as<It,Iterator>)
```
dengan ini masing2 overload function sudah punya task dan utility masing-masing dan menghindari collision atau tabrakan 
---

# Checklist
##### Umum:
- [x] Saya menambah algoritma terbaru.
- [x] Saya menambah dokumentasi.

##### Contributor Requirements (Syarat Kontributor) dan Lain-Lain:
- [x] Saya telah menambahkan komentar kode yang memberikan penjelasan maksud dari kode yang saya buat.
- [x] Saya menggunakan bahasa Indonesia untuk memberikan penjelasan dari kode yang saya buat.

---

# Environment
Saya menggunakan (I'm using):
- ``OS`` = `Linux` <!-- if you dont use linux you can rewrite this --> 
- ``g++`` = `15.2.1`

---

# Link Issues

Issues: # <!-- if don't have a issue,please do not fill this>

---

# License
This Commit License  
https://github.com/Build-X-From-Scratch/forward_list_sratch/blob/main/LICENSE